### PR TITLE
Fix issue #3: Update session threshold when prayers are deleted

### DIFF
--- a/Prayerify/Messages/PrayerCountChangedMessage.cs
+++ b/Prayerify/Messages/PrayerCountChangedMessage.cs
@@ -1,0 +1,12 @@
+namespace Prayerify.Messages
+{
+    public class PrayerCountChangedMessage
+    {
+        public int NewCount { get; }
+
+        public PrayerCountChangedMessage(int newCount)
+        {
+            NewCount = newCount;
+        }
+    }
+}

--- a/Prayerify/ViewModels/EditPrayerViewModel.cs
+++ b/Prayerify/ViewModels/EditPrayerViewModel.cs
@@ -1,6 +1,8 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
 using Prayerify.Data;
+using Prayerify.Messages;
 using Prayerify.Models;
 using Prayerify.Services;
 using System.Collections.ObjectModel;
@@ -78,7 +80,14 @@ namespace Prayerify.ViewModels
 				CategoryId = SelectedCategory?.Id,
 			};
 			await _database.UpsertPrayerAsync(model);
-			await _database.UpdatePrayerCountAsync();
+			var newCount = await _database.UpdatePrayerCountAsync();
+			
+			// Notify that prayer count has changed (only if adding a new prayer)
+			if (Id == 0)
+			{
+				WeakReferenceMessenger.Default.Send(new PrayerCountChangedMessage(newCount));
+			}
+			
 			await Shell.Current.GoToAsync("..");
 		}
 	}

--- a/Prayerify/ViewModels/PrayersViewModel.cs
+++ b/Prayerify/ViewModels/PrayersViewModel.cs
@@ -1,6 +1,8 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
 using Prayerify.Data;
+using Prayerify.Messages;
 using Prayerify.Models;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
@@ -121,6 +123,11 @@ namespace Prayerify.ViewModels
 			if (prayer == null) return;
 			await _database.DeletePrayerAsync(prayer.Id);
 			Prayers.Remove(prayer);
+			_allPrayers.Remove(prayer);
+			
+			// Notify that prayer count has changed
+			var newCount = _allPrayers.Count;
+			WeakReferenceMessenger.Default.Send(new PrayerCountChangedMessage(newCount));
 		}
 
 		[RelayCommand]
@@ -148,6 +155,10 @@ namespace Prayerify.ViewModels
 			{
 				Prayers.Remove(prayer);
 				_allPrayers.Remove(prayer);
+				
+				// Notify that prayer count has changed
+				var newCount = _allPrayers.Count;
+				WeakReferenceMessenger.Default.Send(new PrayerCountChangedMessage(newCount));
 			}
 		}
 

--- a/Prayerify/ViewModels/SessionSetupViewModel.cs
+++ b/Prayerify/ViewModels/SessionSetupViewModel.cs
@@ -1,12 +1,14 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
 using Prayerify.Data;
+using Prayerify.Messages;
 using Prayerify.Pages;
 using System.ComponentModel;
 
 namespace Prayerify.ViewModels
 {
-	public partial class SessionSetupViewModel : BaseViewModel
+	public partial class SessionSetupViewModel : BaseViewModel, IRecipient<PrayerCountChangedMessage>, IDisposable
 	{
 		private readonly IPrayerDatabase _database;
 
@@ -24,6 +26,9 @@ namespace Prayerify.ViewModels
 			_database = database;
 			Title = "Prayer Session";
 			PropertyChanged += OnPropertyChanged;
+			
+			// Register for prayer count change messages
+			WeakReferenceMessenger.Default.Register(this);
 		}
 
 		[RelayCommand]
@@ -71,6 +76,27 @@ namespace Prayerify.ViewModels
 					CanStartSession = false;
 				}
 			}
+		}
+		
+		/// <summary>
+		/// Receives notification when prayer count changes
+		/// </summary>
+		public void Receive(PrayerCountChangedMessage message)
+		{
+			// Update the total prayer count
+			TotalPrayerCount = message.NewCount;
+			
+			// Ensure Count doesn't exceed the maximum
+			if (Count > TotalPrayerCount)
+			{
+				Count = TotalPrayerCount;
+			}
+		}
+		
+		// Clean up when this object is disposed
+		public void Dispose()
+		{
+			WeakReferenceMessenger.Default.Unregister<PrayerCountChangedMessage>(this);
 		}
     }
 }


### PR DESCRIPTION
 Problem
     The max session threshold stayed above prayer total after prayers were deleted, allowing users to start sessions with more prayers than actually exist.
     
     Solution
     - Added messaging system using CommunityToolkit.Mvvm's WeakReferenceMessenger
     - SessionSetupViewModel now listens for prayer count changes and auto-adjusts the session threshold
     - Prayer deletions and additions now notify other ViewModels in real-time
     
     Changes
     - Created `PrayerCountChangedMessage` for cross-ViewModel communication
     - Updated `PrayersViewModel` to send messages when prayers are deleted/answered
     - Updated `EditPrayerViewModel` to send messages when prayers are added
     - Updated `SessionSetupViewModel` to receive and react to prayer count changes